### PR TITLE
GitHub repo ID is obtained from GitHub API (#3)

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -8,7 +8,7 @@ org = {
 }
 
 urls = dict(
-    github_api='https://api.github.com/repos/'
+    github_api='https://api.github.com/repos'
 )
 
 url_mgmnt_sys = dict(

--- a/settings.py
+++ b/settings.py
@@ -2,6 +2,15 @@ repo = dict(
     AZUL = 139095537
 )
 
+org = {
+    'DataBiosphere': ['azul'],
+    'ucsc-cgp': ['sync-test']
+}
+
+urls = dict(
+    github_api='https://api.github.com/repos/'
+)
+
 url_mgmnt_sys = dict(
     jira_url='https://ucsc-cgl.atlassian.net',
     zenhub_url='https://api.zenhub.io/p1/repositories/'

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import requests
+import os
+import errno
+import logging
+from settings import org, urls
+from more_itertools import one
+from urllib.parse import urljoin
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+FORMAT = '%(asctime)-15s %(message)s'
+logging.basicConfig(format=FORMAT)
+
+
+def get_repo_id(repo_name):
+    check_for_git_config('.gitconfig')
+    url = _get_repo_url(repo_name)
+    response = requests.get(url)
+    if response.status_code == 200:
+        response_json = response.json()
+        return {'repo_id': response_json['id']}
+    else:
+        return {'repo_id': response.reason}
+
+
+def check_for_git_config(git_config_file):
+    """
+    User must have ~/.gitconfig in home directory in order to use this function.
+    """
+    logging.info('Checking whether .gitconfig exists on local system')
+    user_home = os.path.expanduser('~')
+    if not os.path.isfile(os.path.join(user_home, git_config_file)):
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), git_config_file)
+
+
+def _get_repo_url(repo_name):
+    """
+    Return URL using GitHub API for repo_name
+    (use look-up-table to return GitHub organization from repo name)
+    """
+    base_url = urls['github_api']
+    _org = [k for k, v in org.items() if repo_name in v]
+    if _org == []:
+        raise ValueError(f'Cannot find organization for {repo_name}')
+    assert len(_org) == 1
+    organization = one(_org)
+    url = f'{organization}/{repo_name}'
+
+    return urljoin(base=base_url, url=url)

--- a/src/zenhub.py
+++ b/src/zenhub.py
@@ -16,19 +16,23 @@ FORMAT = '%(asctime)-15s %(message)s'
 logging.basicConfig(format=FORMAT)
 
 def main():
-    repo_name = sys.argv[1]
-    issue = sys.argv[2]
+    org_name = sys.argv[1]
+    repo_name = sys.argv[2]
+    issue = sys.argv[3]
 
-    zen = ZenHub(repo_name=repo_name, issue=issue)
+    zen = ZenHub(org_name=org_name, repo_name=repo_name, issue=issue)
     print(json.dumps(zen.get_info()))
 
 
 class ZenHub():
 
-    def __init__(self, repo_name, issue):
+    def __init__(self, org_name, repo_name, issue):
         self.access_params = get_access_params(mgmnt_sys='zenhub')
+        self.org_name = org_name
         self.repo_name = repo_name
-        d = get_repo_id(repo_name)
+        d = get_repo_id(repo_name, org_name)
+        if d['status_code'] is not 200:
+            raise ValueError(f'Check if {repo_name} is an existing repository the organization {org_name}.')
         self.repo_id = str(d['repo_id'])
         self.issue = str(issue)
         self.url = self._generate_url()

--- a/src/zenhub.py
+++ b/src/zenhub.py
@@ -7,7 +7,7 @@ import requests
 import json
 sys.path.append(".")
 from src.access import get_access_params
-from settings import repo
+from src.utilities import get_repo_id
 
 
 logger = logging.getLogger()
@@ -19,17 +19,17 @@ def main():
     repo_name = sys.argv[1]
     issue = sys.argv[2]
 
-    zen = ZenHub(repo_name=repo_name,
-                 issue=issue)
+    zen = ZenHub(repo_name=repo_name, issue=issue)
     print(json.dumps(zen.get_info()))
 
 
 class ZenHub():
 
-    def __init__(self, repo_name=None, issue=None):
+    def __init__(self, repo_name, issue):
         self.access_params = get_access_params(mgmnt_sys='zenhub')
         self.repo_name = repo_name
-        self.repo_id = self._get_repo_id(repo_name)
+        d = get_repo_id(repo_name)
+        self.repo_id = str(d['repo_id'])
         self.issue = str(issue)
         self.url = self._generate_url()
 
@@ -62,15 +62,6 @@ class ZenHub():
     def _generate_url(self):
         _url = self.access_params['options']['server']
         return os.path.join(_url, self.repo_id, 'issues', self.issue)
-
-    # TODO: very temporary: need to use GitHub API to return repo_id in the future
-    @staticmethod
-    def _get_repo_id(repo_name):
-        try:
-            if repo_name == 'azul':
-                return str(repo['AZUL'])
-        except ValueError as err:
-            logger.info(f'{repo_name} is not a known repo')
 
 
 if __name__ == '__main__':

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -38,8 +38,7 @@ def mocked_response(*args):
     elif args == ('https://api.github.com/repos/DataBiosphere/foobar',):
         return MockResponse(
             {'message': 'Not Found',
-             'documentation_url': 'https://developer.github.com/v3/repos/#get'}
-            ,
+             'documentation_url': 'https://developer.github.com/v3/repos/#get'},
             404,
             'Not Found'
         )
@@ -48,36 +47,31 @@ def mocked_response(*args):
 class TestUtilities(unittest.TestCase):
 
     @patch.dict(urls, {'github_api': 'http://foo.bar'}, clear=True)
-    @patch.dict(org, {'someorg': ['one', 'two', 'three']}, clear=True)
     def test_get_repo_url(self):
-        url_expected = 'http://foo.bar/someorg/two'
-        url_observed = _get_repo_url('two')
+        url_expected = 'http://foo.bar/someorg/somerepo'
+        url_observed = _get_repo_url('somerepo', 'someorg')
         self.assertEqual(url_expected, url_observed, 'GitHub repo URL malformed')
-
-    @patch.dict(urls, {'github_api': 'http://foo.bar'}, clear=True)
-    @patch.dict(org, {'someorg': ['one', 'two', 'three']}, clear=True)
-    def test_get_repo_url_found_no_org(self):
-        self.assertRaises(ValueError, _get_repo_url, repo_name='four')
 
     @patch('requests.get', side_effect=mocked_response)
     def test_get_repo_id(self, mocked_resp):
         mocked_resp = mocked_response('https://api.github.com/repos/DataBiosphere/azul',)
-        repo_id = get_repo_id('azul')
-        self.assertDictEqual({'repo_id': mocked_resp.json_data['id']}, repo_id)
+        repo_id = get_repo_id('azul', 'DataBiosphere')
+        self.assertEqual(mocked_resp.json_data['id'], repo_id['repo_id'])
 
     @patch('src.utilities._get_repo_url')
     @patch('requests.get', side_effect=mocked_response)
     def test_get_repo_id_non_existent_repo(self, mocked_resp, mock_get_repo_url):
         mocked_resp = mocked_response('https://api.github.com/repos/DataBiosphere/foobar',)
         mock_get_repo_url.return_value = 'https://api.github.com/repos/DataBiosphere/foobar'
-        repo_id = get_repo_id('foobar')
-        self.assertDictEqual({'repo_id': mocked_resp.reason}, repo_id)
+        repo_id = get_repo_id('foobar', 'DataBiosphere')
+        self.assertEqual(mocked_resp.reason, repo_id['repo_id'])
+        self.assertEqual(mocked_resp.status_code, repo_id['status_code'])
 
     def test_check_for_git_config(self):
         config_file = '/tmp/foobar'
         if os.path.isfile(config_file):
-            os.remove('/tmp/foobar')
-        self.assertRaises(FileNotFoundError, check_for_git_config, '/tmp/foobar')
+            os.remove(config_file)
+        self.assertRaises(FileNotFoundError, check_for_git_config, config_file)
 
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+
+import unittest
+import os
+from unittest.mock import patch
+from settings import org, urls
+from src.utilities import get_repo_id, _get_repo_url, check_for_git_config
+
+
+def mocked_response(*args):
+    """Create class to mock requests response."""
+
+    class MockResponse:
+        def __init__(self, json_data, status_code, reason):
+            self.json_data = json_data
+            self.status_code = status_code
+            self.reason = reason
+
+        def json(self):
+            return self.json_data
+
+    # Careful, args needs to be a tuple, and that always ends with a "," character in Python!!
+    if args == ('https://api.github.com/repos/DataBiosphere/azul',):
+        return MockResponse(
+            {'id': 42,
+             'node_id': 'MDEwOlJlcG9zaXRvcnkxMzkwOTU1Mzc=',
+             'name': 'azul',
+             'full_name': 'DataBiosphere/azul',
+             'private': False,
+             'owner': {'login': 'DataBiosphere',
+                       'id': 32805087
+                       }
+             },
+            200,
+            'OK'
+        )
+    elif args == ('https://api.github.com/repos/DataBiosphere/foobar',):
+        return MockResponse(
+            {'message': 'Not Found',
+             'documentation_url': 'https://developer.github.com/v3/repos/#get'}
+            ,
+            404,
+            'Not Found'
+        )
+
+
+class TestUtilities(unittest.TestCase):
+
+    @patch.dict(urls, {'github_api': 'http://foo.bar'}, clear=True)
+    @patch.dict(org, {'someorg': ['one', 'two', 'three']}, clear=True)
+    def test_get_repo_url(self):
+        url_expected = 'http://foo.bar/someorg/two'
+        url_observed = _get_repo_url('two')
+        self.assertEqual(url_expected, url_observed, 'GitHub repo URL malformed')
+
+    @patch.dict(urls, {'github_api': 'http://foo.bar'}, clear=True)
+    @patch.dict(org, {'someorg': ['one', 'two', 'three']}, clear=True)
+    def test_get_repo_url_found_no_org(self):
+        self.assertRaises(ValueError, _get_repo_url, repo_name='four')
+
+    @patch('requests.get', side_effect=mocked_response)
+    def test_get_repo_id(self, mocked_resp):
+        mocked_resp = mocked_response('https://api.github.com/repos/DataBiosphere/azul',)
+        repo_id = get_repo_id('azul')
+        self.assertDictEqual({'repo_id': mocked_resp.json_data['id']}, repo_id)
+
+    @patch('src.utilities._get_repo_url')
+    @patch('requests.get', side_effect=mocked_response)
+    def test_get_repo_id_non_existent_repo(self, mocked_resp, mock_get_repo_url):
+        mocked_resp = mocked_response('https://api.github.com/repos/DataBiosphere/foobar',)
+        mock_get_repo_url.return_value = 'https://api.github.com/repos/DataBiosphere/foobar'
+        repo_id = get_repo_id('foobar')
+        self.assertDictEqual({'repo_id': mocked_resp.reason}, repo_id)
+
+    def test_check_for_git_config(self):
+        config_file = '/tmp/foobar'
+        if os.path.isfile(config_file):
+            os.remove('/tmp/foobar')
+        self.assertRaises(FileNotFoundError, check_for_git_config, '/tmp/foobar')
+
+
+
+
+
+
+
+
+

--- a/tests/test_zenhub.py
+++ b/tests/test_zenhub.py
@@ -1,8 +1,9 @@
 #!/usr/env/python3
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from src.zenhub import ZenHub
+from settings import org
 
 
 def mocked_response(*args, **kwargs):
@@ -18,6 +19,7 @@ def mocked_response(*args, **kwargs):
             return self.json_data
 
     # Careful, args needs to be a tuple, and that always ends with a "," character in Python!!
+    # Happy Path:
     if args == ('https://api.zenhub.io/p1/repositories/123456789/issues/42',) and \
             kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
         return MockResponse(
@@ -28,6 +30,7 @@ def mocked_response(*args, **kwargs):
             200,
             'Ok'
         )
+    # Non-existent issue number:
     elif args == ('https://api.zenhub.io/p1/repositories/123456789/issues/55555555',) and \
             kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
         return MockResponse(
@@ -35,6 +38,7 @@ def mocked_response(*args, **kwargs):
             404,
             'Not found'
         )
+    # Non-existent repo number
     elif args == ('https://api.zenhub.io/p1/repositories/100000000/issues/55555555',) and \
             kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
         return MockResponse(
@@ -46,31 +50,29 @@ def mocked_response(*args, **kwargs):
         assert False
 
 
-class ZenHub_with_mocked_token(ZenHub):
-    def __init__(self, repo_name=None, issue=None):
+class ZenHubWithMockedToken(ZenHub):
+    def __init__(self, repo_name, issue):
         self.access_params = {'options': 'https://api.zenhub.io/p1/repositories', 'api_token': 99999999}
         self.repo_name = repo_name
-        self.repo_id = self._get_repo_id(repo_name)
+        self.repo_id = 123456789
         self.issue = str(issue)
         self.url = self._generate_url()
 
 
 class TestZenHub(unittest.TestCase):
-
+    @patch('src.utilities.get_repo_id')
     @patch('src.zenhub.ZenHub._generate_url')
-    @patch('src.zenhub.ZenHub._get_repo_id')
     @patch('requests.get', side_effect=mocked_response)
-    def test_happy_path(self, mocked_get_info, mock_repo_id, mock_generate_url):
-        repo_name = 'azul'
+    def test_happy_path(self, mocked_get_info, mock_generate_url, mock_repo_id):
+        repo_name = 'foo'
         issue = 42
 
-        mock_repo_id.return_value = 123456789
+        mock_repo_id.return_value = {'repo_id': 123456789}
         mock_generate_url.return_value = (
-            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value}/issues/{issue}")
+            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value['repo_id']}/issues/{issue}")
+        res = ZenHubWithMockedToken(repo_name=repo_name, issue=issue)
 
-        res = ZenHub_with_mocked_token(repo_name=repo_name, issue=issue)
-
-        self.assertEqual(res.repo_id, mock_repo_id.return_value, 'incorrect repo_id')
+        self.assertEqual(res.repo_id, mock_repo_id.return_value['repo_id'], 'incorrect repo_id')
         self.assertEqual(res.issue, str(issue), 'incorrect issue number')
         self.assertEqual(res.url, mock_generate_url.return_value, 'incorrect URL')
 
@@ -83,19 +85,19 @@ class TestZenHub(unittest.TestCase):
                          'get_info has incorrect output')
 
     @patch('src.zenhub.ZenHub._generate_url')
-    @patch('src.zenhub.ZenHub._get_repo_id')
+    @patch('src.utilities.get_repo_id')
     @patch('requests.get', side_effect=mocked_response)
     def test_existing_repo_ID_nonexisting_issue_num(self, mocked_get_info, mock_repo_id, mock_generate_url):
-        repo_name = 'azul'
+        repo_name = 'bar'
         issue = 55555555
 
-        mock_repo_id.return_value = 123456789
+        mock_repo_id.return_value = {'repo_id': 123456789}
         mock_generate_url.return_value = (
-            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value}/issues/{issue}")
+            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value['repo_id']}/issues/{issue}")
 
-        res = ZenHub_with_mocked_token(repo_name=repo_name, issue=issue)
+        res = ZenHubWithMockedToken(repo_name=repo_name, issue=issue)
 
-        self.assertEqual(res.repo_id, mock_repo_id.return_value, 'incorrect repo_id')
+        self.assertEqual(res.repo_id, mock_repo_id.return_value['repo_id'], 'incorrect repo_id')
         self.assertEqual(res.issue, str(issue), 'incorrect issue number')
         self.assertEqual(res.url, mock_generate_url.return_value, 'incorrect URL')
 
@@ -103,19 +105,27 @@ class TestZenHub(unittest.TestCase):
         self.assertEqual(res.get_info(), {'message': 'Issue not found'}, 'get_info has incorrect output')
 
     @patch('src.zenhub.ZenHub._generate_url')
-    @patch('src.zenhub.ZenHub._get_repo_id')
+    @patch('src.utilities.get_repo_id')
     @patch('requests.get', side_effect=mocked_response)
     def test_nonexisting_repo_ID_nonexisting_issue_num(self, mocked_get_info, mock_repo_id, mock_generate_url):
-        repo_name = 'azul'
+        repo_name = 'baz'
         issue = 55555555
 
-        mock_repo_id.return_value = 100000000
+        mock_repo_id.return_value = {'repo_id':100000000}
         mock_generate_url.return_value = (
-            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value}/issues/{issue}")
+            f"https://api.zenhub.io/p1/repositories/{mock_repo_id.return_value['repo_id']}/issues/{issue}")
 
-        res = ZenHub_with_mocked_token(repo_name=repo_name, issue=issue)
+        class ZenHubWithMockedTokenNonexistRepoId(ZenHubWithMockedToken):
+            def __init__(self, repo_name, issue):
+                self.access_params = {'options': 'https://api.zenhub.io/p1/repositories', 'api_token': 99999999}
+                self.repo_name = repo_name
+                self.repo_id = 100000000
+                self.issue = str(issue)
+                self.url = self._generate_url()
 
-        self.assertEqual(res.repo_id, mock_repo_id.return_value, 'incorrect repo_id')
+        res = ZenHubWithMockedTokenNonexistRepoId(repo_name, issue)
+
+        self.assertEqual(res.repo_id, mock_repo_id.return_value['repo_id'], 'incorrect repo_id')
         self.assertEqual(res.issue, str(issue), 'incorrect issue number')
         self.assertEqual(res.url, mock_generate_url.return_value, 'incorrect URL')
 
@@ -123,12 +133,14 @@ class TestZenHub(unittest.TestCase):
         self.assertEqual(res.get_info(), {'message': 'Invalid Field for repo_id: repo_id is a required field'},
                          'get_info has incorrect output')
 
+    @patch.dict(org, {'someorg': ['foo', 'bar', 'baz']}, clear=True)
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101})
     @patch('src.zenhub.ZenHub._generate_url', return_value='https://foo.bar')
-    def test_generate_url(self, mock_generate_url):
+    def test_generate_url(self, mock_generate_url, mock_repo_id):
 
         zen = ZenHub(repo_name='baz', issue=42)
+        self.assertTrue(isinstance(zen.repo_id, str), 'instance attribute repo_id must be of type str')
         self.assertEqual(zen.url, 'https://foo.bar', 'URL not generated correctly')
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* added module `utilities.py`, which contains def `get_repo_id`
* added `test_utilities.py`
* made adjustments in `zenhub.py` and its tests to use new functionality
* changed org dictionary in `settings.py` to include the GitHub
`ucsc-cgp` organization
* user only inputs name of repo, function finds corresponding
organization (or none if it doesn't exist) - but this might be
not optimal and we might want to ask user to also specify organization
* code checks whether user has `.gitconfig` in home directory
(perhaps more specific checks are needed)

┆Issue is synchronized with this [Jira Task](https://ucsc-cgl.atlassian.net/browse/SAB-18)
┆Project Name: sync-agile-boards
┆Issue Number: SAB-18
