### PR TITLE
Zenhub class can update issues and points, and can turn an issue into an epic (#33)

### DIFF
--- a/src/zenhub.py
+++ b/src/zenhub.py
@@ -30,6 +30,7 @@ class ZenHub():
         self.access_params = get_access_params(mgmnt_sys='zenhub')
         self.org_name = org_name
         self.repo_name = repo_name
+        self.headers = {'X-Authentication-Token': self.access_params['api_token'], 'Content-Type': 'application/json'}
         d = get_repo_id(repo_name, org_name)
         if d['status_code'] is not 200:
             raise ValueError(f'Check if {repo_name} is an existing repository the organization {org_name}.')
@@ -41,8 +42,7 @@ class ZenHub():
     def get_info(self):
         url = self._generate_url()
         logger.info(f'Getting pipeline, storypoints and timestamp for story {self.issue} in repo {self.repo_name}')
-        headers = {'X-Authentication-Token': self.access_params['api_token']}
-        response = requests.get(url, headers=headers, verify=False)
+        response = requests.get(url, headers=self.headers, verify=False)
         if response.status_code == 200:
             data = response.json()
             pipeline = data['pipeline']['name']
@@ -66,6 +66,102 @@ class ZenHub():
     def _generate_url(self):
         _url = self.access_params['options']['server']
         return os.path.join(_url, self.repo_id, 'issues', self.issue)
+
+    def _update_issue_points(self, value):
+        # Change the point estimate for the issue.
+        logger.info(f'Changing the current value of story points to {value}')
+
+        url = os.path.join(self.url, 'estimate')
+        json_dict = {'estimate': value}
+        response = requests.put(url, headers=self.headers, json=json_dict)
+
+        if response.status_code == 200:
+            logger.info(f'Success. {self.issue} now has a story points value of {value}')
+        else:
+            logger.info(
+                f'Error occured when updating issue points. Status Code: {response.status_code}. Reason: {response.reason}')
+            raise RuntimeError(
+                f'Error occured when updating issue points. Status Code: {response.status_code}. Reason: {response.reason}')
+
+    def _update_issue_pipeline(self, pipeline, pos=None):
+        # Change the pipeline of an issue.
+
+        # See https://github.com/ZenHubIO/API#move-an-issue-between-pipelines for further documentation.
+
+        # pipeline: A string representing a valid pipeline present in this in ZenHub repo ('New Issue', 'Icebox'...)
+        #           Checked against the pipelines found in ZenHub_get_pipeline_ids() and stored in self.pipeline_ids.
+        # pos: Either 'top', 'bottom', or a 0-based position in the array of tickets in this pipeline.
+        pipeline = pipeline.title()
+        if pipeline in self.pipeline_ids:
+            logger.info(f'Changing the current value of pipeline to {pipeline}')
+
+            url = os.path.join(self.url, 'moves')
+            json_dict = {'pipeline_id': self.pipeline_ids[pipeline], 'position': pos or 'top'}
+
+            response = requests.post(url, headers=self.headers, json=json_dict)
+
+            if response.status_code == 200:
+                logger.info(f'Success. {self.issue} was moved to {pipeline}')
+            else:
+                logger.info(
+                    f'Error occured when moving issue to new pipeline. Status Code: {response.status_code}. Reason: {response.reason}')
+                raise RuntimeError(
+                    f'Error occured when moving issue to new pipeline. Status Code: {response.status_code}. Reason: {response.reason}')
+        else:
+            logger.info(f'{pipeline} is not a valid pipeline.')
+
+    def _update_issue_to_epic(self):
+        # Change the issue into an Epic.
+        logger.info(f'Turning {self.issue} into an epic in repo {self.repo_name}')
+
+        url = os.path.join(self.url, 'convert_to_epic')
+        json_dict = {'issues': [{'repo_id': self.repo_id, 'issue_number': self.issue}]}
+        response = requests.put(url, headers=self.headers, json=json_dict)
+
+        if response.status_code == 200:
+            logger.info(f'Success. {self.issue} was converted to an Epic')
+        else:
+            logger.info(
+                f'Error occured when updating issue to epic. Status Code: {response.status_code}. Reason: {response.reason}')
+            raise RuntimeError(
+                f'Error occured when updating issue to epic. Status Code: {response.status_code}. Reason: {response.reason}')
+
+    def _get_pipeline_ids(self):
+        # Determine the valid pipeline IDs for this repo.
+        logger.info(f'Retrieving pipeline ids for {self.repo_name}.')
+        url = os.path.join(self.access_params['options']['server'], self.repo_id, 'board')
+        response = requests.get(url, headers=self.headers)
+
+        if response.status_code == 200:
+            logger.info(f'Successfully retrieved pipeline ids for {self.repo_name}.')
+            data = response.json()
+            ids = {pipeline['name']: pipeline['id'] for pipeline in data['pipelines']}
+            return ids
+        else:
+            logger.info(
+                f'Error in retreiving pipeline ids. Status Code: {response.status_code}. Reason: {response.reason}')
+            raise RuntimeError(
+                f'Error in retreiving pipeline ids. Status Code: {response.status_code}. Reason: {response.reason}')
+
+    def update_issue(self, points=None, pipeline=None, pipeline_pos=None, to_epic=False):
+        """
+        Update the information of a ZenHub Issue.
+        :param int points: The number of points the issue should have.
+        :param str pipeline: The pipeline the issue should move to.
+        :param str or int pipeline_pos: The issue's position in the new pipeline. 'top', 'bottom', or 0-based index.
+                                        If unspecified, defaults to 'top'.
+        :param bool to_epic: Should the ticket be changed into an Epic?
+        """
+        logger.info(f'Beginning updating {self.issue} in repo {self.repo_name}')
+
+        if points:
+            self._update_issue_points(points)
+        if pipeline:
+            self._update_issue_pipeline(pipeline, pipeline_pos)
+        if to_epic:
+            self._update_issue_to_epic()
+
+        logger.info(f'Finished updating {self.issue} in repo {self.repo_name}')
 
 
 if __name__ == '__main__':

--- a/tests/test_zenhub.py
+++ b/tests/test_zenhub.py
@@ -21,7 +21,7 @@ def mocked_response(*args, **kwargs):
     # Careful, args needs to be a tuple, and that always ends with a "," character in Python!!
     # Happy Path:
     if args == ('https://api.zenhub.io/p1/repositories/123456789/issues/42',) and \
-            kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
+            kwargs == {'headers': {'X-Authentication-Token': 99999999, 'Content-Type': 'application/json'}, 'verify': False}:
         return MockResponse(
             {'estimate': {'value': 2},
              'plus_ones': [],
@@ -32,7 +32,7 @@ def mocked_response(*args, **kwargs):
         )
     # Non-existent issue number:
     elif args == ('https://api.zenhub.io/p1/repositories/123456789/issues/55555555',) and \
-            kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
+            kwargs == {'headers': {'X-Authentication-Token': 99999999, 'Content-Type': 'application/json'}, 'verify': False}:
         return MockResponse(
             {'message': 'Issue not found'},
             404,
@@ -40,15 +40,16 @@ def mocked_response(*args, **kwargs):
         )
     # Non-existent repo number
     elif args == ('https://api.zenhub.io/p1/repositories/100000000/issues/55555555',) and \
-            kwargs == {'headers': {'X-Authentication-Token': 99999999}, 'verify': False}:
+            kwargs == {'headers': {'X-Authentication-Token': 99999999, 'Content-Type': 'application/json'}, 'verify': False}:
         return MockResponse(
             {'message': 'Invalid Field for repo_id: repo_id is a required field'},
             422,
             'Unprocessable Entity'
         )
+    elif '/board' in args[0]:  # The request used for determining pipeline ids in _get_pipeline_ids().
+        return MockResponse({'pipelines': [{'id': 12345, 'name': 'Done', 'issues': []}]}, 200, 'OK')
     else:
-        assert False
-
+        raise RuntimeError(args, kwargs)
 
 
 class TestZenHub(unittest.TestCase):
@@ -128,6 +129,107 @@ class TestZenHub(unittest.TestCase):
         self.assertEqual(zen.repo_name, 'bar')
         self.assertTrue(isinstance(zen.repo_id, str), 'instance attribute repo_id must be of type str')
         self.assertEqual(zen.url, 'https://foo.bar', 'URL not generated correctly')
+
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101, 'status_code': 200})
+    @patch('os.path.join')
+    @patch('requests.put')
+    def test_update_issue_points(self, mock_put_change_points, mock_url_creator, mock_repo_id):
+        """Test that ZenHub.update_issue_points() works."""
+        issue_num = 42
+        new_points = 3
+        mock_url_creator.return_value = f'https://api.zenhub.io/p1/repositories/issues/{issue_num}/estimate'
+        mock_put_change_points.return_value.status_code = 200
+
+        zen = ZenHub(org_name='foo', repo_name='azul', issue=issue_num)
+        zen._update_issue_points(new_points)
+
+        mock_put_change_points.assert_called()
+        request_args = list(mock_put_change_points.call_args)
+
+        # Check that the url is in the request
+        self.assertIn((mock_url_creator.return_value,), request_args)  # MagicMock stores this as a tuple.
+
+        # Check that the json_dict is in the put request.
+        expected_dict = {'headers': zen.headers.copy()}
+        expected_dict.update({'json': {'estimate': new_points}})
+        self.assertIn(expected_dict, request_args)
+
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101, 'status_code': 200})
+    @patch('os.path.join')
+    @patch('requests.post')
+    def test_update_issue_pipeline(self, mock_post_change_pipeline, mock_url_creator, mock_repo_id):
+        """Test that ZenHub.update_issue_pipeline() works."""
+        issue_num = 42
+        mock_url_creator.return_value = f'https://api.zenhub.io/p1/repositories/issues/{issue_num}/moves'
+        mock_post_change_pipeline.return_value.status_code = 200
+
+        zen = ZenHub(org_name='foo', repo_name='azul', issue=issue_num)
+        zen.pipeline_ids = {'Icebox': 12345}
+        zen._update_issue_pipeline('Icebox')
+
+        mock_post_change_pipeline.assert_called()
+        request_args = list(mock_post_change_pipeline.call_args)
+
+        # Check that the url is in the request
+        self.assertIn((mock_url_creator.return_value,), request_args)  # MagicMock stores this as a tuple.
+
+        # Check that the json_dict is in the put request.
+        expected_dict = {'headers': zen.headers.copy()}
+        expected_dict.update({'json': {'pipeline_id': 12345, 'position': 'top'}})
+        self.assertIn(expected_dict, request_args)
+
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101, 'status_code': 200})
+    @patch('os.path.join')
+    @patch('requests.put')
+    def test_update_issue_to_epic(self, mock_put_make_epic, mock_url_creator, mock_repo_id):
+        """Test that ZenHub.update_issue_to_epic() works."""
+        issue_num = 42
+        repo_name = 'azul'
+        mock_url_creator.return_value = f'https://api.zenhub.io/p1/repositories/issues/{issue_num}/convert_to_epic'
+        mock_put_make_epic.return_value.status_code = 200
+
+        zen = ZenHub(org_name='foo', repo_name=repo_name, issue=issue_num)
+        zen.repo_id = 12345
+        zen._update_issue_to_epic()
+
+        mock_put_make_epic.assert_called()
+        request_args = list(mock_put_make_epic.call_args)
+
+        # Check that the url is in the request
+        self.assertIn((mock_url_creator.return_value,), request_args)  # MagicMock stores this as a tuple.
+
+        # Check that the json_dict is in the put request.
+        expected_dict = {'headers': zen.headers.copy()}
+        expected_dict.update({'json': {'issues': [{'repo_id': zen.repo_id, 'issue_number': str(issue_num)}]}})
+        self.assertIn(expected_dict, request_args)
+
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101, 'status_code': 200})
+    @patch('src.zenhub.ZenHub._update_issue_to_epic')
+    @patch('src.zenhub.ZenHub._update_issue_pipeline')
+    @patch('src.zenhub.ZenHub._update_issue_points')
+    def test_update_issue(self, mock_update_issue_points, mock_update_issue_pipeline, mock_update_issue_to_epic, mock_repo_id):
+        """Test that ZenHub.update_ticket() works."""
+        issue_num = 42
+        repo_name = 'azul'
+
+        zen = ZenHub(org_name='foo', repo_name=repo_name, issue=issue_num)
+        zen.update_issue(points=3, pipeline='Icebox', to_epic=True)
+
+        mock_update_issue_points.assert_called()
+        mock_update_issue_pipeline.assert_called()
+        mock_update_issue_to_epic.assert_called()
+
+    @patch('src.zenhub.get_repo_id', return_value={'repo_id': 101, 'status_code': 200})
+    @patch('requests.get', side_effect=mocked_response)
+    def test_get_pipeline_ids(self, mocked_get_info, mocked_get_repo_id):
+        """Test that ZenHub._get_pipeline_ids() works."""
+        path_to_token = '~/foo/bar/baz.txt'
+        repo_name = 'azul'
+        issue = 55555555
+
+        res = ZenHub(org_name='foo', repo_name=repo_name, issue=issue)
+
+        self.assertEqual(res._get_pipeline_ids(), {'Done': 12345})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR will add the ability for instances of the ZenHub class to update point values, pipelines, and set them to epics. It also includes tests.

┆Issue is synchronized with this [Jira Task](https://ucsc-cgl.atlassian.net/browse/SAB-20)
┆Project Name: sync-agile-boards
┆Issue Number: SAB-20
